### PR TITLE
Abort the reload if the new server fails to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 # Test servers
 /integration_tests/test_servers/simple/server
 /integration_tests/test_servers/double_listen/server
+/integration_tests/test_servers/errorer/server
 /integration_tests/test_servers/v*

--- a/integration_tests/test_servers/Makefile
+++ b/integration_tests/test_servers/Makefile
@@ -1,5 +1,5 @@
 
-SERVERS = simple/server double_listen/server v1/server v2/server
+SERVERS = simple/server double_listen/server v1/server v2/server errorer/server
 
 all: $(SERVERS)
 

--- a/integration_tests/test_servers/errorer/server.go
+++ b/integration_tests/test_servers/errorer/server.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os"
+	"time"
+)
+
+func main() {
+	time.Sleep(50 * time.Millisecond)
+
+	os.Exit(1)
+}

--- a/listener.go
+++ b/listener.go
@@ -105,6 +105,7 @@ func (l *gracefulListener) prepareFd() (fd int, err error) {
 	if err != nil {
 		return 0, err
 	}
+	defer fl.Close()
 
 	// The TCPListener.File() sets the underlying socket to be blocking
 	// (http://git.io/veIh6).  This alters the behaviour of Accept such that

--- a/listener.go
+++ b/listener.go
@@ -106,6 +106,16 @@ func (l *gracefulListener) prepareFd() (fd int, err error) {
 		return 0, err
 	}
 
+	// The TCPListener.File() sets the underlying socket to be blocking
+	// (http://git.io/veIh6).  This alters the behaviour of Accept such that
+	// when the listener fd is closed, Accept doesn't return an error until the
+	// next connection comes in.
+	//
+	// Setting this back to non-blocking allows this to continue to use the
+	// epoll mechanism meaning that Accept will return an error immediately
+	// when the listener fd is closed.
+	syscall.SetNonblock(int(fl.Fd()), true)
+
 	// Dup the fd to clear the CloseOnExec flag
 	fd, err = syscall.Dup(int(fl.Fd()))
 	if err != nil {

--- a/manager.go
+++ b/manager.go
@@ -183,8 +183,13 @@ func listenFdFromEnv(ident string) int {
 func (m *manager) handleSignals() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGHUP)
-	_ = <-c
 
+	for _ = range c {
+		m.handleHUP()
+	}
+}
+
+func (m *manager) handleHUP() {
 	m.listenersLock.Lock()
 	defer m.listenersLock.Unlock()
 


### PR DESCRIPTION
To prevent interruption to service it's preferable to continue running the old code.

If a reload fails, tablecloth will continue to listen for future reload signals, and can
therefore reload gracefully when a working new version is deployed.
